### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ nltk
 gensim
 scikit-learn==0.20.2
 scipy
-numpy==1.16.4
+numpy==1.19.2
 seqeval
 h5py
 tqdm==4.35.0


### PR DESCRIPTION
The numpy version 16.2 does not support the random generator function in numpy.random module.